### PR TITLE
clsoe #34 fixed error during db migrate

### DIFF
--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -7,4 +7,4 @@ module Spree
 end
 
 # patch attr detail, details attrs for rich edit need to move to other spree extensions
-Spree::Product.prepend(Spree::ProductDecorator) if !Spree::Product.column_names.include?('detail')
+Spree::Product.prepend(Spree::ProductDecorator)


### PR DESCRIPTION
This PR fixes an error that occur during `db:migrate`

When migrating, the `if !Spree::Product.column_names.include?('detail')` try to hits database even before the database was created.